### PR TITLE
Remove flowbite

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "aewx-metar-parser": "^1.0.0",
     "axios": "^1.2.0",
     "core-js": "^3.26.1",
-    "flowbite": "^1.5.3",
     "flowbite-datepicker": "^1.2.2",
     "leaflet": "^1.9.2",
     "pinia": "^2.0.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,7 +2755,7 @@ flowbite-datepicker@^1.2.2:
   dependencies:
     flowbite "^1.4.5"
 
-flowbite@^1.4.5, flowbite@^1.5.3:
+flowbite@^1.4.5:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/flowbite/-/flowbite-1.5.5.tgz#0adb062e1c5b31dfd1e71bd1acfcda6cbc69e728"
   integrity sha512-LWJteH6zO+6BrnerH6GEU9OFpjWmkCWi9BD3XnJdBOVevNnt7u8gW+S+4keqD5OGpHu+QU860pLzNKeNlhlf6g==


### PR DESCRIPTION
Remove flowbite, this changed something in tailwind CSS between 1.5.3 and 1.5.5 that messed up our header alignment. Since we don't use it, let's just get rid of it.