### PR TITLE
fix date handling so it's based off local instead of UTC

### DIFF
--- a/src/views/pages/ActivityPage.vue
+++ b/src/views/pages/ActivityPage.vue
@@ -90,13 +90,14 @@ onMounted(() => {
   const today = new Date();
   for (let i = 0; i < 3; i += 1) {
     const nd = new Date();
+    nd.setDate(1);
     nd.setMonth(today.getMonth() - i);
     const month = nd.getMonth() + 1;
     const year = nd.getFullYear();
     months.value.push(`${monthNames[month]} ${year}`);
     endpointMonths.push(`${year}/${month}`);
   }
-  ZDVAPI.get("/v1/stats/historical")
+  ZDVAPI.get(`/v1/stats/historical/${endpointMonths[0]}`)
     .then((res) => {
       curMonth.value = res.data.sort((a: ControllerStats, b: ControllerStats) => {
         if (a.last_name < b.last_name) return -1;


### PR DESCRIPTION
When determining months, it's based off of today, which will fail if a previous month doesn't have that day (ie the 31st). Also the /v1/stats/historical is based off of UTC, so if we render Jan on the frontend after 0000 UTC, the API will return nothing thinking it's the next month while we're still expecting Jan's information.