### PR TITLE
Scroll bar for Flights on homepage

### DIFF
--- a/src/components/home/OnlineFlights.vue
+++ b/src/components/home/OnlineFlights.vue
@@ -12,20 +12,22 @@
         <div class="w-1/5 text-center">Arr.</div>
       </div>
       <!-- Sort by callsign -->
-      <div
-        v-for="flight in overflights.sort((a, b) => (a.callsign > b.callsign ? 1 : -1))"
-        :key="flight.cid"
-        class="flex items-center"
-      >
-        <div :class="{ 'w-2/5': props.showType, 'w-3/5': !props.showType }">{{ flight.callsign }}</div>
-        <div v-if="props.showType" class="w-1/5 text-center invisible sm:visible">
-          {{ flight.type !== "" ? flight.type : "??" }}
-        </div>
-        <div class="w-1/5 text-center">
-          {{ flight.dep !== "" ? flight.dep : "??" }}
-        </div>
-        <div class="w-1/5 text-center">
-          {{ flight.arr !== "" ? flight.arr : "??" }}
+      <div class="max-h-[249px] overflow-y-auto">
+        <div
+          v-for="flight in overflights.sort((a, b) => (a.callsign > b.callsign ? 1 : -1))"
+          :key="flight.cid"
+          class="flex items-center"
+        >
+          <div :class="{ 'w-2/5': props.showType, 'w-3/5': !props.showType }">{{ flight.callsign }}</div>
+          <div v-if="props.showType" class="w-1/5 text-center invisible sm:visible">
+            {{ flight.type !== "" ? flight.type : "??" }}
+          </div>
+          <div class="w-1/5 text-center">
+            {{ flight.dep !== "" ? flight.dep : "??" }}
+          </div>
+          <div class="w-1/5 text-center">
+            {{ flight.arr !== "" ? flight.arr : "??" }}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
During events the page gets insanely long, with majority of it being blank space. This adds a scroll bar to the flights card on the homepage.