### PR TITLE
changes to flight table

### DIFF
--- a/src/components/home/OnlineFlights.vue
+++ b/src/components/home/OnlineFlights.vue
@@ -15,17 +15,17 @@
       <div
         v-for="flight in overflights.sort((a, b) => (a.callsign > b.callsign ? 1 : -1))"
         :key="flight.cid"
-        class="flex items-center"
+        class="flex items-center dark:hover:bg-neutral-700 hover:bg-neutral-300"
       >
         <div :class="{ 'w-2/5': props.showType, 'w-3/5': !props.showType }">{{ flight.callsign }}</div>
         <div v-if="props.showType" class="w-1/5 text-center invisible sm:visible">
-          {{ flight.type !== "" ? flight.type : "??" }}
+          {{ flight.type !== "" ? flight.type : "-" }}
         </div>
         <div class="w-1/5 text-center">
-          {{ flight.dep !== "" ? flight.dep : "??" }}
+          {{ flight.dep !== "" ? flight.dep : "-" }}
         </div>
         <div class="w-1/5 text-center">
-          {{ flight.arr !== "" ? flight.arr : "??" }}
+          {{ flight.arr !== "" ? flight.arr : "-" }}
         </div>
       </div>
     </div>

--- a/src/facilities/zan/views/pages/Homepage.vue
+++ b/src/facilities/zan/views/pages/Homepage.vue
@@ -34,10 +34,12 @@
       <div class="card">
         <OnlineControllers />
       </div>
-      <div class="card mt-4"><OnlineFlights /></div>
     </div>
     <div class="card col-span-4 h-min flex flex-col">
       <WeatherTable :stations="['PAFA', 'PANC', 'PABE', 'PADQ', 'PAEN']" rules show-updated sort title grid-size="5" />
+    </div>
+    <div class="card col-span-4 h-min">
+      <OnlineFlights show-type />
     </div>
     <div class="card col-span-4 h-min">
       <TopControllers />

--- a/src/facilities/zdv/views/pages/Homepage.vue
+++ b/src/facilities/zdv/views/pages/Homepage.vue
@@ -31,12 +31,12 @@
       <div class="card">
         <OnlineControllers />
       </div>
-      <div class="card mt-4">
-        <OnlineFlights />
-      </div>
     </div>
     <div class="card col-span-4 h-min flex flex-col">
       <WeatherTable :stations="['KASE', 'KPUB', 'KCOS', 'KDEN', 'KAPA']" rules show-updated sort title grid-size="5" />
+    </div>
+    <div class="card col-span-4 h-min">
+      <OnlineFlights />
     </div>
     <div class="card col-span-4 h-min">
       <TopControllers />


### PR DESCRIPTION
Changes flight table for ZDV and ZAN to be under the weather strip, adds type to the table, and adds a slight hover effect to the onlineflights component. This should better display flights, especially when events cause it to be lengthy.