### PR TITLE
Add weight and sorting to navbar sublinks

### DIFF
--- a/src/components/header/HeaderNavItem.vue
+++ b/src/components/header/HeaderNavItem.vue
@@ -26,7 +26,7 @@
       v-if="props.sublinks.length > 0"
       class="top-full left-0 absolute w-[200px] bg-white dark:bg-black-deep border-b-[3px] border-primary py-4 shadow-md shadow-black/20 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 translate-y-[20px] group-hover:translate-y-0 z-30"
     >
-      <li v-for="(link, index) in props.sublinks" :key="index">
+      <li v-for="(link, index) in sublinkcomputed" :key="index">
         <AuthLink
           v-if="link.to"
           :to="link.to"
@@ -52,6 +52,7 @@
 
 <script setup lang="ts">
 import AuthLink from "@/components/AuthLink.vue";
+import { computed } from "vue";
 import { Link } from "@/types";
 
 const props = withDefaults(defineProps<Link>(), {
@@ -68,6 +69,18 @@ const checkClick = (): boolean => {
   }
   return true;
 };
+
+const sublinkcomputed = computed(() => {
+  const sublinks = props.sublinks;
+  return sublinks.sort((a, b) => {
+    // Sort by weight, then title
+    if ((a.weight || 0) < (b.weight || 0)) return -1;
+    if ((a.weight || 0) > (b.weight || 0)) return 1;
+    if (a.title < b.title) return -1;
+    if (a.title > b.title) return 1;
+    return 0;
+  });
+});
 </script>
 
 <style scoped></style>

--- a/src/facility-zan.ts
+++ b/src/facility-zan.ts
@@ -11,6 +11,7 @@ const fac: Facility = {
   devApiUrl: "https://api.dev.vzanartcc.net",
   hasOceanicCert: true,
   navbarClasses: "bg-alaska-blue dark:bg-alaska-blue text-white",
+  resources: ["Policies", "LOAs", "VRC", "vSTARS", "vERAM", "vATIS", "Misc"],
   customRoutes: [
     {
       path: "/",
@@ -833,7 +834,7 @@ const fac: Facility = {
       title: "Facility",
       sublinks: [
         {
-          title: "SOPs",
+          title: "Facility SOPs",
           href: "https://sops.vzanartcc.net",
         },
       ],

--- a/src/links.ts
+++ b/src/links.ts
@@ -6,6 +6,7 @@ const ProfileLinks: Link[] = [
   {
     title: "Discord Dashboard",
     href: `https://discord.${fac.domain}/`,
+    weight: -1,
   },
   {
     title: "My Training Notes",
@@ -16,6 +17,7 @@ const ProfileLinks: Link[] = [
     title: "Logout",
     href: `${apiUrl}/v1/user/logout?redirect=${window.location.href}`,
     sameWindow: true,
+    weight: 999,
   },
 ];
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -63,6 +63,7 @@ export interface Link {
   auth?: boolean;
   roles?: string[];
   sameWindow?: boolean;
+  weight?: number;
 }
 
 export type FacilityAirport = {
@@ -87,6 +88,7 @@ export type Facility = {
   center: [number, number];
   domain: string;
   defaultZoom: number;
+  resources?: string[];
   customRoutes?: RouteRecordRaw[];
   boundaries: { [key: string]: [number, number][] };
   airports: FacilityAirport[];

--- a/src/views/pages/Resources.vue
+++ b/src/views/pages/Resources.vue
@@ -175,6 +175,7 @@
 import { API, ZDVAPI } from "@/utils/api";
 import { hasRole, isAuthenticated } from "@/utils/auth";
 import { onMounted, ref, Ref } from "vue";
+import fac from "@/facility";
 import type { Resource } from "@/types";
 import Spinner from "@/components/Spinner.vue";
 import { useRouter } from "vue-router";
@@ -189,7 +190,8 @@ const editingResource = ref({
   saving: false,
 });
 const loaded = ref(true);
-const categories = ["SOPs", "LOAs", "VRC", "vSTARS", "vERAM", "vATIS", "Misc"];
+
+const categories = fac.resources || ["SOPs", "LOAs", "VRC", "vSTARS", "vERAM", "vATIS", "Misc"];
 const openTab: Ref<string | null> = ref(categories[0]);
 const router = useRouter();
 const resources: Ref<Resource[]> = ref([]);


### PR DESCRIPTION
Add optional `weight` field to links allowing sorting by weight, then alphabetically by title. Logout is defaulted to 999 to have it last in Profile menu, the rest will default a weight of 0 unless otherwise defined. Discord Dashboard is also weighted by default to -1 to try and keep it first.