### PR TITLE
Fix staffing requets feature

### DIFF
--- a/src/facilities/zdv/views/pages/StaffingRequest.vue
+++ b/src/facilities/zdv/views/pages/StaffingRequest.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1 class="text-2xl">Staffing Request</h1>
-    <div v-if="userStore.user !== null">
+    <div v-if="userStore.user === null">
       <p class="pb-2">To access the staffing request form, please first login with VATSIM.</p>
       <a
         class="btn py-4 px-4 bg-colorado-blue hover:bg-blue-900"


### PR DESCRIPTION
The condition to check if the user is logged in was reversed, allowing anon. users to see the form, and restricting logged-in users to just the login button.