### PR TITLE
Weather badges on homepage show METAR on hover

### DIFF
--- a/src/components/weather/WeatherBadge.vue
+++ b/src/components/weather/WeatherBadge.vue
@@ -1,6 +1,7 @@
 <template>
   <button
     :class="`wx-badge wx-badge-${props.flightCategory.toLowerCase()} ${props.slim ? 'wx-badge-slim' : ''}`"
+    :title="props.raw"
     disabled
   >
     {{ props.flightCategory }}
@@ -11,6 +12,7 @@
 const props = defineProps<{
   flightCategory: string;
   slim?: boolean;
+  raw?: string;
 }>();
 </script>
 

--- a/src/components/weather/WeatherRow.vue
+++ b/src/components/weather/WeatherRow.vue
@@ -9,7 +9,7 @@
     <div v-if="props.clouds">{{ props.weather.clouds }}</div>
     <div v-if="props.precipitation">{{ props.weather.precipitation }}</div>
     <div v-if="props.rules" class="text-right">
-      <WeatherBadge :flight-category="props.weather.rules" slim />
+      <WeatherBadge :flight-category="props.weather.rules" :raw="props.weather.raw" slim />
     </div>
   </div>
 </template>
@@ -28,6 +28,7 @@ type WeatherType = {
   clouds: string;
   precipitation: string;
   rules: string;
+  raw: string;
 };
 
 interface Props {

--- a/src/components/weather/WeatherTable.vue
+++ b/src/components/weather/WeatherTable.vue
@@ -46,6 +46,7 @@ type WeatherType = {
   clouds: string;
   precipitation: string;
   rules: string;
+  raw: string;
 };
 
 interface Props {
@@ -132,6 +133,7 @@ const updateWeather = (): void => {
         visibility: `${metar.visibility?.miles} nm`,
         precipitation: metar.conditions.join(" "),
         rules: (metar.flight_category as string).toLowerCase(),
+        raw,
       };
       if ((metar.wind?.speed_kts as number) < 3) {
         w.wind = "Calm";


### PR DESCRIPTION
Simply sets the DOM element "title" attribute. No affect on pilot weather page.

![screenshot](https://github.com/adh-partnership/frontend/assets/772507/7d69e544-61aa-4ac7-93f0-2ed337d4223c)

Fixes #318