### PR TITLE
Make the event pos. creation modal less stateful

### DIFF
--- a/src/views/partials/events/CreatePositionModal.vue
+++ b/src/views/partials/events/CreatePositionModal.vue
@@ -83,6 +83,8 @@ const props = defineProps<Props>();
 const toggleModal = (): void => {
   isOpen.value = !isOpen.value;
   window.scrollTo(0, 0);
+  position.value.position = "";
+  error.value = null;
 };
 
 const canCreatePosition = (): boolean => {
@@ -135,6 +137,7 @@ const createPosition = async (): Promise<void> => {
           .then(() => {
             isOpen.value = false;
             position.value.position = "";
+            error.value = null;
           })
           .catch(() => {
             buttonState.value = ButtonStates.Error;


### PR DESCRIPTION
The position creation modal no longer persists the user-entered position string, as well as more eagerly clears its error state.

![add_pos_change](https://github.com/adh-partnership/frontend/assets/772507/bef0172f-2196-4f3f-b4a4-b2c678fa94f1)
