### PR TITLE
Prevent vertical overlapping of event pos assign.

### DIFF
--- a/src/views/partials/events/Positions.vue
+++ b/src/views/partials/events/Positions.vue
@@ -17,7 +17,7 @@
               <button
                 type="button"
                 class="btn bg-yellow-400 text-white font-bold py-0.5 px-2 ml-2 rounded"
-                @click="assign[position.id] = !assign[position.id]"
+                @click="() => toggleAssignDropdown(position.id)"
               >
                 <i class="fas fa-user"></i>
               </button>
@@ -96,7 +96,7 @@
               <button
                 type="button"
                 class="btn bg-yellow-400 text-white font-bold py-0.5 px-2 ml-2 rounded"
-                @click="assign[position.id] = !assign[position.id]"
+                @click="() => toggleAssignDropdown(position.id)"
               >
                 <i class="fas fa-user"></i>
               </button>
@@ -175,7 +175,7 @@
               <button
                 type="button"
                 class="btn bg-yellow-400 text-white font-bold py-0.5 px-2 ml-2 rounded"
-                @click="assign[position.id] = !assign[position.id]"
+                @click="() => toggleAssignDropdown(position.id)"
               >
                 <i class="fas fa-user"></i>
               </button>
@@ -332,13 +332,23 @@ type Props = {
 };
 const props = defineProps<Props>();
 
-const assign = ref({});
+const assign = ref<Record<number, boolean>>({});
 
 const toggleModal = (s: string): void => {
   assignPosSelected.value = s;
   isOpen.value = !isOpen.value;
   window.scrollTo(0, 0);
   error.value = null;
+};
+
+const toggleAssignDropdown = (id: number): void => {
+  for (const pos of Object.keys(assign.value)) {
+    const position = parseInt(pos);
+    if (position !== id) {
+      assign.value[parseInt(pos)] = false;
+    }
+  }
+  assign.value[id] = !assign.value[id];
 };
 
 const enroutePositions = computed(() => {


### PR DESCRIPTION
The `<Positions />` component now only toggles on the dropdown assignment menu on for a single position in its column. There isn't any cross-component restriction, so the user can still have dropdowns open from the 3 columns.

![event_assign_progress](https://github.com/adh-partnership/frontend/assets/772507/f5bab8fc-bb41-43d5-a721-0daa75d2c244)

Fixes #319