### PR TITLE
Change the ZDV training link to internal site

### DIFF
--- a/src/facility-zdv.ts
+++ b/src/facility-zdv.ts
@@ -236,7 +236,7 @@ const fac: Facility = {
       sublinks: [
         {
           title: "Schedule Training",
-          href: "https://www.picktime.com/vzdv",
+          href: "https://training.zdvartcc.org",
         },
       ],
     },


### PR DESCRIPTION
Changing the training link from Picktime to the new training site.