### PR TITLE
Update minimum controller rating to S3 for ZDV/ZLC

### DIFF
--- a/src/facility-zdv.ts
+++ b/src/facility-zdv.ts
@@ -6,7 +6,7 @@ const fac: Facility = {
   name: "Denver ARTCC",
   logo: "https://cdn.zdvartcc.org/assets/img/logo_150.png",
   skipMajor: false,
-  minVisitorRating: "S1",
+  minVisitorRating: "S3",
   domain: "zdvartcc.org",
   apiUrl: "https://api.zdvartcc.org",
   devApiUrl: "https://api.dev.zdvartcc.org",

--- a/src/facility-zlc.ts
+++ b/src/facility-zlc.ts
@@ -6,7 +6,7 @@ const fac: Facility = {
   name: "Salt Lake City ARTCC",
   logo: "https://cdn.zlcartcc.org/assets/img/logo.png",
   skipMajor: false,
-  minVisitorRating: "S1",
+  minVisitorRating: "S3",
   domain: "zlcartcc.org",
   apiUrl: "https://api.zlcartcc.org",
   devApiUrl: "https://api.dev.zlcartcc.org",


### PR DESCRIPTION
This follows the immediate change announced today by VATUSA2.