### PR TITLE
Add Filtering to the Roster Table

### DIFF
--- a/src/views/pages/RosterPage.vue
+++ b/src/views/pages/RosterPage.vue
@@ -7,7 +7,7 @@
       <div v-else-if="fetched && error !== ''">
         <div class="m-3">Error getting roster: {{ error }}</div>
       </div>
-      <div v-else><RosterTable :roster="activeControllers"></RosterTable></div>
+      <div v-else><RosterTable :roster="activeControllers" :certifications="certifications"></RosterTable></div>
     </div>
   </div>
 </template>
@@ -22,7 +22,7 @@ import useRosterStore from "@/stores/roster";
 const fetched = ref(false);
 const error = ref("");
 const rosterStore = useRosterStore();
-const { controllers } = storeToRefs(rosterStore);
+const { controllers, certifications } = storeToRefs(rosterStore);
 
 const activeControllers = computed(() => controllers.value.filter((c) => c.controller_type !== "none"));
 

--- a/src/views/partials/roster/RosterTable.vue
+++ b/src/views/partials/roster/RosterTable.vue
@@ -1,7 +1,8 @@
 <template>
+  <RosterFilterPanel v-model="filteredRoster" :roster="roster" :certifications="certifications" />
   <div>
     <table
-      v-for="(controller, index) in props.roster"
+      v-for="(controller, index) in filteredRoster"
       :key="controller.cid"
       class="w-full cursor-pointer"
       :class="{ 'bg-slate-100 dark:bg-slate-800': (index - 1) % 2, 'dark:bg-slate-900 bg-slate-50': index % 2 }"
@@ -37,14 +38,19 @@
 <script setup lang="ts">
 import { useRouter } from "vue-router";
 
-import type { Controller } from "@/types";
+import type { CertificationItem, Controller } from "@/types";
 import ControllerCertificationBadges from "@/components/ControllerCertificationBadges.vue";
 import { getControllerTitle } from "@/utils/helpers";
+import RosterFilterPanel from "@/views/partials/roster/filtering/RosterFilterPanel.vue";
+import { ref } from "vue";
 
 const router = useRouter();
 const props = defineProps<{
   roster: Controller[];
+  certifications: CertificationItem[];
 }>();
+
+const filteredRoster = ref(props.roster);
 
 const goToController = (cid: number): void => {
   router.push(`/roster/${cid}`);

--- a/src/views/partials/roster/filtering/RosterFilterPanel.vue
+++ b/src/views/partials/roster/filtering/RosterFilterPanel.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="p-4 bg-white dark:bg-gray-800 rounded-lg shadow-md">
+    <!-- Input Box Filter -->
+    <div class="flex flex-col items-start pb-3">
+      <label for="search" class="text-lg font-medium text-gray-700 dark:text-gray-300">Search</label>
+      <input
+        id="search"
+        v-model="search"
+        type="text"
+        class="rounded-md border border-gray-300 dark:border-gray-700 p-2 w-full focus:outline-none focus:ring-2 focus:ring-blue-500"
+        placeholder="Search for a controller..."
+        @input="filterAndEmit"
+      />
+    </div>
+
+    <!-- Dropdown Filters -->
+    <div class="flex flex-wrap space-x-4">
+      <!-- Generate dropdown for each filter option -->
+      <div
+        v-for="(filter, filterKey) in filters"
+        :key="filterKey"
+        class="flex flex-col items-start space-y-1 space-x-1 mb-4 flex-grow"
+      >
+        <label :for="`filter_${filterKey}`" class="text-lg capitalize font-medium text-gray-700 dark:text-gray-300">
+          {{ filter.label }}
+        </label>
+        <select
+          :id="`filter_${filterKey}`"
+          v-model="filter.value"
+          class="rounded-md border border-gray-300 dark:border-gray-700 p-2 w-full focus:outline-none focus:ring-2 focus:ring-blue-500"
+          @change="filterAndEmit"
+        >
+          <option value="">Select {{ filter.label }}</option>
+          <option v-for="option in filter.options" :key="option" :value="option">
+            {{ option }}
+          </option>
+        </select>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { CertificationItem, Controller } from "@/types";
+
+// Props
+const props = defineProps<{ roster: Controller[]; modelValue: Controller[]; certifications: CertificationItem[] }>();
+
+// Refs
+const search = ref("");
+
+// Emits
+const emit = defineEmits(["update:modelValue"]);
+
+// Filters that get dynamically rendered into Dropdowns.
+const filters: Filter[] = [
+  {
+    label: "Rating",
+    filterFunction: (controller: Controller, value: string) => controller.rating === value,
+    options: ["OBS", "S1", "S2", "S3", "C1", "C2", "I1", "I2", "I3", "SUP", "ADM"],
+    value: "",
+  },
+  {
+    label: "Certification",
+    filterFunction: (controller: Controller, value: string) => {
+      return Object.values(controller.certifications).some(
+        (cert) => cert.display_name === value && cert.value !== "none"
+      );
+    },
+    options: props.certifications.map((cert) => cert.display_name),
+    value: "",
+  },
+  {
+    label: "Type",
+    filterFunction: (controller: Controller, value: string) =>
+      controller.controller_type.toLowerCase() === value.toLowerCase(),
+    options: ["Home", "Visitor"],
+    value: "",
+  },
+];
+
+function filterAndEmit(): void {
+  const searchFiltered = props.roster.filter((controller) => {
+    return `${controller.first_name} ${controller.last_name}`.toLowerCase().includes(search.value.toLowerCase());
+  });
+
+  const dropdownFiltered = searchFiltered.filter((controller) => {
+    return filters.every((filter) => {
+      return filter.value === "" || filter.filterFunction(controller, filter.value);
+    });
+  });
+
+  emit("update:modelValue", dropdownFiltered);
+}
+
+type Filter = {
+  label: string;
+  filterFunction: (controller: Controller, value: string) => boolean;
+  options: string[];
+  value: string;
+};
+</script>


### PR DESCRIPTION
The existing roster page was visually nice, but I was having trouble navigating through the list. I added a panel that allows users to select filters to reduce the roster table.

I am somewhat familiar with Vue 3 and using the composition API with `script setup`. 

I looked around for contributing information, and I didn't see anything, so I hope this is okay. I'm happy to make any changes!

I tried to follow the method of passing refs into components instead of loading the stores and other patterns I noticed.

## Testing

I tested using each of the facility files to ensure the certification options were being pulled in correctly. Things seemed to work as expected.